### PR TITLE
Add completions message to mirrord brew caveats

### DIFF
--- a/mirrord.rb
+++ b/mirrord.rb
@@ -9,29 +9,22 @@ class Mirrord < Formula
   on_macos do
     url "https://github.com/metalbear-co/mirrord/releases/download/3.68.0/mirrord_mac_universal.zip"
     sha256 "2ce5d18705880cc29568b40413b10fb38adbad6a34ed0db660f7784036da56a3"
-
-    def install
-      bin.install "mirrord"
-    end
   end
 
   on_linux do
     if Hardware::CPU.arm? && Hardware::CPU.is_64_bit?
       url "https://github.com/metalbear-co/mirrord/releases/download/3.68.0/mirrord_linux_aarch64.zip"
       sha256 "0959c1ec621558775fb8599bc591b1c19c564835190c639c19c0aa141e1b01ed"
-
-      def install
-        bin.install "mirrord"
-      end
     end
     if Hardware::CPU.intel? && Hardware::CPU.is_64_bit?
       url "https://github.com/metalbear-co/mirrord/releases/download/3.68.0/mirrord_linux_x86_64.zip"
       sha256 "7635e85e278bae890f1ab3a6e181de34cc9257d4145cc5d2dec2fd119c612ad3"
-
-      def install
-        bin.install "mirrord"
-      end
     end
+  end
+
+  def install
+    bin.install "mirrord"
+    generate_completions_from_executable(bin/"mirrord", "completions")
   end
 
   test do

--- a/mirrord.rb
+++ b/mirrord.rb
@@ -28,14 +28,13 @@ class Mirrord < Formula
 
   def caveats
     <<~EOS
-      mirrord has been installed but you'll need to manually generate and source
-      the completions for your shell like:
+      mirrord has been installed, but if you'd like shell completions you'll
+      need to manually generate the completions for your shell like
 
-        source <(mirrord completions bash)
+        mirrord completions <bash|zsh|fish>
 
-      And equivalent for other shells. Check the documentation for more info:
-
-        mirrord completions --help
+      To ensure it's always available you can add it to Homebrew's default locations.
+      Follow their instructions here: https://docs.brew.sh/Shell-Completion
     EOS
   end
 

--- a/mirrord.rb
+++ b/mirrord.rb
@@ -24,7 +24,19 @@ class Mirrord < Formula
 
   def install
     bin.install "mirrord"
-    generate_completions_from_executable(bin/"mirrord", "completions")
+  end
+
+  def caveats
+    <<~EOS
+      mirrord has been installed but you'll need to manually generate and source
+      the completions for your shell like:
+
+        source <(mirrord completions bash)
+
+      And equivalent for other shells. Check the documentation for more info:
+
+        mirrord completions --help
+    EOS
   end
 
   test do


### PR DESCRIPTION
Printing completions steps as part of the post install caveats since mirrord is a universal binary and brew won't run it.
Also pulls out install method to make things a bit less repetitive

EDIT: Removed that it addresses #2 as this just adds the caveats on install, not actually installing completions.