### PR TITLE
Fix linux version issue with explicit version

### DIFF
--- a/mirrord.rb
+++ b/mirrord.rb
@@ -5,6 +5,8 @@ class Mirrord < Formula
   desc "Connect your local process and your cloud environment"
   homepage "https://mirrord.dev"
   license "MIT"
+  version 3.157.0
+  version_scheme 1
 
   on_macos do
     url "https://github.com/metalbear-co/mirrord/releases/download/3.157.0/mirrord_mac_universal.zip"


### PR DESCRIPTION
The version_scheme is also bumped so that 3.x versions are larger than 86.64

Fixes #6 .